### PR TITLE
Fix translation loading

### DIFF
--- a/Update_Clover/update_clover/logger.py
+++ b/Update_Clover/update_clover/logger.py
@@ -31,8 +31,13 @@ def load_translations(language=None):
     print(f"Tentando carregar traduções de: {translations_path}/{language}.json")
     try:
         with open(f"{translations_path}/{language}.json", "r", encoding="utf-8") as f:
-            translations = json.load(f)
-        logger(f"Traduções carregadas com sucesso para o idioma: {language}", GREEN)
+            data = json.load(f)
+            translations = data.get(language, {})
+        if not translations and language != "en":
+            logger("language_section_not_found", YELLOW, language=language)
+            load_translations("en")
+        else:
+            logger(f"Traduções carregadas com sucesso para o idioma: {language}", GREEN)
     except FileNotFoundError:
         logger("translation_file_not_found", RED, language=language)
         # Carrega o idioma padrão (inglês) se o arquivo de tradução não for encontrado

--- a/Update_Clover/update_clover/main.py
+++ b/Update_Clover/update_clover/main.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import os
-from config import LOGFILE, SCRIPT_DIR
+from config import LOGFILE, SCRIPT_DIR, RED
 from utils import check_environment, check_dependencies, cleanup, CloverUpdateError
 from efi_handler import list_all_efi, backup_efi
 from clover_updater import download_clover


### PR DESCRIPTION
## Summary
- load inner mapping from translation files
- fall back to English if the language section is missing
- import `RED` constant to allow error logging

## Testing
- `LC_ALL=pt_BR.UTF-8 python3 Update_Clover/update_clover/main.py`
- `LC_ALL=en_US.UTF-8 python3 Update_Clover/update_clover/main.py`


------
https://chatgpt.com/codex/tasks/task_e_684ce75e8128832894768ace8c9ac1a4

## Summary by Sourcery

Fix translation loading by correctly retrieving nested language mappings, falling back to English on missing sections or files, and improving log messages

Bug Fixes:
- Extract the nested language section from translation files using data.get(language)
- Fallback to English translations when the specified language section or file is missing

Enhancements:
- Log a warning if a language section is not found
- Import the RED constant to support error logging